### PR TITLE
Print exception instead of assuming gcloud error

### DIFF
--- a/cloud/envs/gcp.py
+++ b/cloud/envs/gcp.py
@@ -24,8 +24,8 @@ class GCPInstance(env.Instance):
     # Check for dependencies
     try:
       utils.call(["gcloud", "--version"])
-    except:
-      raise Exception("Missing commandline utility: gcloud")
+    except Exception as e:
+      print(e)
 
     self.tpu = TPUManager(self)
     self.resource_managers = [self.tpu]

--- a/cloud/envs/gcp.py
+++ b/cloud/envs/gcp.py
@@ -25,7 +25,7 @@ class GCPInstance(env.Instance):
     try:
       utils.call(["gcloud", "--version"])
     except Exception as e:
-      print(e)
+      raise(e)
 
     self.tpu = TPUManager(self)
     self.resource_managers = [self.tpu]


### PR DESCRIPTION
The hardcoded error message is misleading; errors can arise due to issues which are not due to missing gcloud (e.g. mine was "Connection refused")