### PR TITLE
Add fixes to remove hostname assumption and avoid using alpha in commands

### DIFF
--- a/cloud/envs/gcp.py
+++ b/cloud/envs/gcp.py
@@ -79,7 +79,7 @@ class TPU(env.Resource):
     @property
     def details(self):
         _, r, _ = utils.call(
-            ["gcloud", "alpha", "compute", "tpus", "describe", "--zone={}".format(self.manager.zone), self.name])
+            ["gcloud", "compute", "tpus", "describe", "--zone={}".format(self.manager.zone), self.name])
         r = r.split("\n")
         details = dict()
         for line in r:


### PR DESCRIPTION
The previous hostname assumption was causing problems in some execution environments, same with using `alpha` in commands when not necessary (as a prompt appears to confirm authorization). 

I also updated the code to get instance zone to be a bit safer and cleaner.