### PR TITLE
Add config to support google cloud build

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ See `configs/cloud.toml-*` for instructions on how to authenticate for each prov
 
 Place your completed configuration file (named `cloud.toml`) in either root `/` or `$HOME`. Otherwise, provide a full path to the file in `$CLOUD_CFG`.
 
+If you use GCP as a provider for your `cloud.toml` it will use GCP Instance metadata APIs to fetch APIs. If you want to configure for Google Cloud Build, please use; 
+```toml
+is_gcb = true
+zone = '{{DESIRED_ZONE}}' 
+```
+
 ### Usage:
 #### GPU
 ```python

--- a/cloud/envs/gcp.py
+++ b/cloud/envs/gcp.py
@@ -32,6 +32,10 @@ class GCPInstance(env.Instance):
         except Exception as e:
             raise (e)
 
+        if kwargs['config'].get(['is_gcb'], False):
+            self._name = "cloud-build"
+            self._zone = kwargs['config']['zone']
+
         self.tpu = TPUManager(self)
         self.resource_managers = [self.tpu]
 


### PR DESCRIPTION
The APIs used by `GCPInstance` only work with actual gcp instances. This PR enforces config settings to be able to use the `GCPInstance` class to work with GCB. 